### PR TITLE
Add missing github submodule info

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "channel/source/Roku-gameEngine"]
+	path = channel/source/Roku-gameEngine
+	url = https://github.com/Romans-I-XVI/Roku-gameEngine.git

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # Roku-Example-Game
 A basic game using my Roku-gameEngine repository
+
+After cloning this repo, be sure to run `git submodule update --init --recursive` to also pull the code for the Roku-gameEngine. 


### PR DESCRIPTION
Added the .gitmodule file and updated the readme with instructions on how to pull the Roku-gameEngine code into this repo (currently the submodule doesn't work because of the missing .gitmodule file). 